### PR TITLE
Updated to the latest rust

### DIFF
--- a/src/f32x4.rs
+++ b/src/f32x4.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use cgmath::*;
 
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[simd]
 pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
@@ -30,7 +30,7 @@ impl f32x4 {
     }
 }
 
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct f32x4_vec2(pub [f32x4; 2]);
 
 impl f32x4_vec2 {
@@ -52,7 +52,7 @@ impl f32x4_vec2 {
     }
 }
 
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct f32x4_vec3(pub [f32x4; 3]);
 
 impl f32x4_vec3 {
@@ -76,7 +76,7 @@ impl f32x4_vec3 {
     }
 }
 
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[simd]
 pub struct u32x4(pub u32, pub u32, pub u32, pub u32);
 
@@ -100,7 +100,7 @@ impl u32x4 {
 }
 
 
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[simd]
 pub struct u32x2(pub u32, pub u32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(simd, unboxed_closures, core, std_misc)]
+#![feature(simd, unboxed_closures, core, slice_patterns, std_misc)]
 #![allow(non_camel_case_types)]
 
 extern crate image;

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -10,7 +10,7 @@ use {Barycentric, Interpolate, Fragment, Mapping};
 use f32x8::{f32x8x8, f32x8x8_vec3};
 
 
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct TileMask {
     u: f32x8x8,
     v: f32x8x8,
@@ -57,7 +57,7 @@ impl TileMask {
     }
 }
 
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct TileIndex(pub u32);
 
 impl TileIndex {
@@ -131,6 +131,12 @@ struct Quad<T>(pub [T; 4]);
 impl<T: Copy> Quad<T> {
     pub fn new(t: T) -> Quad<T> {
         Quad([t, t, t, t])
+    }
+}
+
+impl<T: Copy> Clone for Quad<T> {
+    fn clone(&self) -> Quad<T> {
+        Quad(self.0)
     }
 }
 


### PR DESCRIPTION
Surprisingly, it fails to compile with this error:
>rustc: /home/rustbuild/src/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/llvm/include/llvm/Support/Casting.h:237: typename llvm::cast_retty<X, Y*>::ret_type llvm::cast(Y*) [with X = llvm::IntegerType; Y = llvm::Type; typename llvm::cast_retty<X, Y*>::ret_type = llvm::IntegerType*]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
